### PR TITLE
implement entity particles custom metadata

### DIFF
--- a/es-base-code/main/default/classes/customerServices.cls
+++ b/es-base-code/main/default/classes/customerServices.cls
@@ -6,8 +6,8 @@ public inherited sharing class customerServices {
             SELECT
                 Customer_Name__r.QualifiedAPIName,
                 Customer_Email__r.QualifiedAPIName,
-                Customer_City__c,
-                Customer_State__c,
+                Customer_City__r.QualifiedAPIName,
+                Customer_State__r.QualifiedAPIName,
                 Customer_Status__r.QualifiedAPIName
             FROM Customer_Fields__mdt
             WHERE Sobject_Type__r.QualifiedAPIName = :objectType
@@ -16,8 +16,8 @@ public inherited sharing class customerServices {
             customer = new Customer(
                 c.Customer_Name__r.QualifiedAPIName,
                 c.Customer_Email__r.QualifiedAPIName,
-                c.Customer_City__c,
-                c.Customer_State__c,
+                c.Customer_City__r.QualifiedAPIName,
+                c.Customer_State__r.QualifiedAPIName,
                 '',
                 ''
             );

--- a/es-base-code/main/default/layouts/Customer_Fields__mdt-Customer Fields Layout.layout-meta.xml
+++ b/es-base-code/main/default/layouts/Customer_Fields__mdt-Customer Fields Layout.layout-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <Layout xmlns="http://soap.sforce.com/2006/04/metadata">
     <layoutSections>
         <customLabel>false</customLabel>
@@ -70,9 +70,9 @@
         <customLabel>false</customLabel>
         <detailHeading>false</detailHeading>
         <editHeading>false</editHeading>
-        <layoutColumns/>
-        <layoutColumns/>
-        <layoutColumns/>
+        <layoutColumns />
+        <layoutColumns />
+        <layoutColumns />
         <style>CustomLinks</style>
     </layoutSections>
     <showEmailCheckbox>false</showEmailCheckbox>

--- a/es-base-code/main/default/layouts/Customer_Fields__mdt-Customer Fields Layout.layout-meta.xml
+++ b/es-base-code/main/default/layouts/Customer_Fields__mdt-Customer Fields Layout.layout-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <Layout xmlns="http://soap.sforce.com/2006/04/metadata">
     <layoutSections>
         <customLabel>false</customLabel>
@@ -70,7 +70,9 @@
         <customLabel>false</customLabel>
         <detailHeading>false</detailHeading>
         <editHeading>false</editHeading>
-        <layoutColumns />
+        <layoutColumns/>
+        <layoutColumns/>
+        <layoutColumns/>
         <style>CustomLinks</style>
     </layoutSections>
     <showEmailCheckbox>false</showEmailCheckbox>

--- a/es-base-code/main/default/objects/Customer_Fields__mdt/fields/Customer_City__c.field-meta.xml
+++ b/es-base-code/main/default/objects/Customer_Fields__mdt/fields/Customer_City__c.field-meta.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Customer_City__c</fullName>
-    <description
-    >Used because Address compound fields aren't yet available as independent fields in entity relationships.</description>
     <externalId>false</externalId>
     <fieldManageability>SubscriberControlled</fieldManageability>
-    <inlineHelpText
-    >Enter the API name of the field that holds the customer's city information.</inlineHelpText>
+    <inlineHelpText>Enter the API name of the field that holds the customer&apos;s city information.</inlineHelpText>
     <label>Customer City</label>
-    <length>55</length>
+    <metadataRelationshipControllingField>Customer_Fields__mdt.Sobject_Type__c</metadataRelationshipControllingField>
+    <referenceTo>EntityParticle</referenceTo>
+    <relationshipLabel>Customer_Fields</relationshipLabel>
+    <relationshipName>Customer_Fields</relationshipName>
     <required>false</required>
-    <type>Text</type>
+    <type>MetadataRelationship</type>
     <unique>false</unique>
 </CustomField>

--- a/es-base-code/main/default/objects/Customer_Fields__mdt/fields/Customer_City__c.field-meta.xml
+++ b/es-base-code/main/default/objects/Customer_Fields__mdt/fields/Customer_City__c.field-meta.xml
@@ -3,8 +3,6 @@
     <fullName>Customer_City__c</fullName>
     <externalId>false</externalId>
     <fieldManageability>SubscriberControlled</fieldManageability>
-    <inlineHelpText
-    >Enter the API name of the field that holds the customer&apos;s city information.</inlineHelpText>
     <label>Customer City</label>
     <metadataRelationshipControllingField
     >Customer_Fields__mdt.Sobject_Type__c</metadataRelationshipControllingField>

--- a/es-base-code/main/default/objects/Customer_Fields__mdt/fields/Customer_City__c.field-meta.xml
+++ b/es-base-code/main/default/objects/Customer_Fields__mdt/fields/Customer_City__c.field-meta.xml
@@ -1,11 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Customer_City__c</fullName>
     <externalId>false</externalId>
     <fieldManageability>SubscriberControlled</fieldManageability>
-    <inlineHelpText>Enter the API name of the field that holds the customer&apos;s city information.</inlineHelpText>
+    <inlineHelpText
+    >Enter the API name of the field that holds the customer&apos;s city information.</inlineHelpText>
     <label>Customer City</label>
-    <metadataRelationshipControllingField>Customer_Fields__mdt.Sobject_Type__c</metadataRelationshipControllingField>
+    <metadataRelationshipControllingField
+    >Customer_Fields__mdt.Sobject_Type__c</metadataRelationshipControllingField>
     <referenceTo>EntityParticle</referenceTo>
     <relationshipLabel>Customer_Fields</relationshipLabel>
     <relationshipName>Customer_Fields</relationshipName>

--- a/es-base-code/main/default/objects/Customer_Fields__mdt/fields/Customer_State__c.field-meta.xml
+++ b/es-base-code/main/default/objects/Customer_Fields__mdt/fields/Customer_State__c.field-meta.xml
@@ -1,11 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Customer_State__c</fullName>
     <externalId>false</externalId>
     <fieldManageability>SubscriberControlled</fieldManageability>
-    <inlineHelpText>Enter the API name of the field that holds the customer&apos;s state information.</inlineHelpText>
+    <inlineHelpText
+    >Enter the API name of the field that holds the customer&apos;s state information.</inlineHelpText>
     <label>Customer State</label>
-    <metadataRelationshipControllingField>Customer_Fields__mdt.Sobject_Type__c</metadataRelationshipControllingField>
+    <metadataRelationshipControllingField
+    >Customer_Fields__mdt.Sobject_Type__c</metadataRelationshipControllingField>
     <referenceTo>EntityParticle</referenceTo>
     <relationshipLabel>Customer_Fields1</relationshipLabel>
     <relationshipName>Customer_Fields1</relationshipName>

--- a/es-base-code/main/default/objects/Customer_Fields__mdt/fields/Customer_State__c.field-meta.xml
+++ b/es-base-code/main/default/objects/Customer_Fields__mdt/fields/Customer_State__c.field-meta.xml
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Customer_State__c</fullName>
-    <description
-    >Used because Address compound fields aren't yet available as independent fields in entity relationships.</description>
     <externalId>false</externalId>
     <fieldManageability>SubscriberControlled</fieldManageability>
-    <inlineHelpText
-    >Enter the API name of the field that holds the customer's state information.</inlineHelpText>
+    <inlineHelpText>Enter the API name of the field that holds the customer&apos;s state information.</inlineHelpText>
     <label>Customer State</label>
-    <length>55</length>
+    <metadataRelationshipControllingField>Customer_Fields__mdt.Sobject_Type__c</metadataRelationshipControllingField>
+    <referenceTo>EntityParticle</referenceTo>
+    <relationshipLabel>Customer_Fields1</relationshipLabel>
+    <relationshipName>Customer_Fields1</relationshipName>
     <required>false</required>
-    <type>Text</type>
+    <type>MetadataRelationship</type>
     <unique>false</unique>
 </CustomField>

--- a/es-base-code/main/default/objects/Customer_Fields__mdt/fields/Customer_State__c.field-meta.xml
+++ b/es-base-code/main/default/objects/Customer_Fields__mdt/fields/Customer_State__c.field-meta.xml
@@ -3,8 +3,6 @@
     <fullName>Customer_State__c</fullName>
     <externalId>false</externalId>
     <fieldManageability>SubscriberControlled</fieldManageability>
-    <inlineHelpText
-    >Enter the API name of the field that holds the customer&apos;s state information.</inlineHelpText>
     <label>Customer State</label>
     <metadataRelationshipControllingField
     >Customer_Fields__mdt.Sobject_Type__c</metadataRelationshipControllingField>


### PR DESCRIPTION
### What does this PR do?

This PR implements Entity Particles for custom metadata type feature documented here (https://releasenotes.docs.salesforce.com/en-us/summer20/release-notes/rn_forcecom_cmt_entity_particle.htm)

### What issues does this PR fix or reference?

We were using text fields for metadata relationships for city and state fields in the app. With Summer 20 we can map individual entities of a compound field like an address.

Earlier one had to use Text fields and put a raw text. This would mean if admins put a wrong API name by mistake the app could break! 

<img width="1782" alt="Screen Shot 2020-07-29 at 9 53 30 PM" src="https://user-images.githubusercontent.com/2276156/88871497-0c768a80-d1e6-11ea-9db6-570218a62b80.png">


## The PR fulfills these requirements:

[ ] Tests for the proposed changes have been added/updated.
No test code required
[ ] Code linting and formatting was performed.
yes

### Functionality Before

<insert gif and/or summary>

### Functionality After

<insert gif and/or summary>
