### PR TITLE
Bump prettier-plugin-apex from 1.8.0 to 1.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "eslint-config-prettier": "^8.1.0",
                 "husky": "^5.2.0",
                 "prettier": "^2.2.1",
-                "prettier-plugin-apex": "^1.8.0",
+                "prettier-plugin-apex": "^1.9.1",
                 "semver": "^7.3.4"
             },
             "engines": {
@@ -15053,9 +15053,9 @@
             }
         },
         "node_modules/prettier-plugin-apex": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-apex/-/prettier-plugin-apex-1.8.0.tgz",
-            "integrity": "sha512-q5gMbL8euYFZ5xg10HM6BWBOn86lPP2QDUqvGVzGhXQFUqCznh4/eqKMy9O/DZ2sHDibZtoNqrMi5KpGBHqjWw==",
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-apex/-/prettier-plugin-apex-1.9.1.tgz",
+            "integrity": "sha512-ixJSe6x8V2j3+g9qQEDiMjgMqw8ijarTpiRZz1Rd76gZKVxaw7DYhO2q6nzkcvntFJi5Y1sIzlcMyJxQRh1Mow==",
             "dev": true,
             "dependencies": {
                 "axios": "^0.21.0",
@@ -15071,6 +15071,9 @@
             },
             "engines": {
                 "node": ">= 10.13.0"
+            },
+            "peerDependencies": {
+                "prettier": "^2.0.0"
             }
         },
         "node_modules/prettier-plugin-apex/node_modules/cliui": {
@@ -30385,9 +30388,9 @@
             "dev": true
         },
         "prettier-plugin-apex": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-apex/-/prettier-plugin-apex-1.8.0.tgz",
-            "integrity": "sha512-q5gMbL8euYFZ5xg10HM6BWBOn86lPP2QDUqvGVzGhXQFUqCznh4/eqKMy9O/DZ2sHDibZtoNqrMi5KpGBHqjWw==",
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-apex/-/prettier-plugin-apex-1.9.1.tgz",
+            "integrity": "sha512-ixJSe6x8V2j3+g9qQEDiMjgMqw8ijarTpiRZz1Rd76gZKVxaw7DYhO2q6nzkcvntFJi5Y1sIzlcMyJxQRh1Mow==",
             "dev": true,
             "requires": {
                 "axios": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "eslint-config-prettier": "^8.1.0",
         "husky": "^5.2.0",
         "prettier": "^2.2.1",
-        "prettier-plugin-apex": "^1.8.0",
+        "prettier-plugin-apex": "^1.9.1",
         "semver": "^7.3.4"
     }
 }


### PR DESCRIPTION
Bumps prettier-plugin-apex from 1.8.0 to 1.9.1.

Signed-off-by: dependabot[bot] <support@github.com>

### What does this PR do?

### What issues does this PR fix or reference?

#<Insert GitHub Issue>

## The PR fulfills these requirements:

[ ] Tests for the proposed changes have been added/updated.
[ ] Code linting and formatting was performed.

### Functionality Before

<insert gif and/or summary>

### Functionality After

<insert gif and/or summary>
